### PR TITLE
Fix dir-out param in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The tools are typically called from commandline or a bash script.
 ### Index metadata
 
 ```
-crawl-metadata --mode=init --dir=/myproject/data [--out-dir=/mnt/myoutput]
+crawl-metadata --mode=init --dir=/myproject/data [--dir-out=/mnt/myoutput]
 ```
 
 Mode explained:


### PR DESCRIPTION
On a related note: I was surprised to see that the .xml files are not generated in the output dir but in the input dir: 

```
C:\tmp\xxx-test> crawl-metadata --mode=export --dir=C:\tmp\xxx-test --dir-out=C:\tmp\xxx-out
export metadata in C:\tmp\xxx-test to C:\tmp\xxx-out
iso19139 generated at C:\tmp\xxx-test\ne_10m_rivers_lake_centerlines.xml
iso19139 generated at C:\tmp\xxx-test\places.xml
iso19139 generated at C:\tmp\xxx-test\srtm_41_19.xml
```

I can open a ticket for that if it is not the intended behavior. 